### PR TITLE
Include cstdint.

### DIFF
--- a/inst/include/utils.h
+++ b/inst/include/utils.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cstdint>
 #include <fstream>
 #include <vector>
 


### PR DESCRIPTION
Adds missing include. Fixes the package to build on Windows using gcc13.
https://gcc.gnu.org/gcc-13/porting_to.html